### PR TITLE
Allow snake_case method names for camelCase properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /tmp/
 .byebug_history
 sapi-client-0.4.6.gem
+.pytest_cache

--- a/lib/sapi_client/sapi_resource.rb
+++ b/lib/sapi_client/sapi_resource.rb
@@ -150,7 +150,7 @@ module SapiClient
       prefix = path_segments(path)
       property = prefix.pop
 
-      target = prefix.reduce(resource) { |res, segment| res[segment] } # rubocop:disable Lint/UnmodifiedReduceAccumulator
+      target = prefix.reduce(resource) { |res, segment| res[segment] }
       target[property] = value
     end
 

--- a/test/sapi_client/sapi_resource_test.rb
+++ b/test/sapi_client/sapi_resource_test.rb
@@ -339,6 +339,11 @@ module SapiClient
         it 'should raise when an unknown message is presented' do
           _(-> { fixture.foo }).must_raise(NoMethodError)
         end
+
+        it 'should allow snake_case method names to be used in place of camelCase' do
+          fixture = SapiClient::SapiResource.new(prefLabel: 'I am Womble!')
+          _(fixture.pref_label).must_equal('I am Womble!')
+        end
       end
 
       describe 'assignment' do


### PR DESCRIPTION
This commit addresses #21 to allow method names used to invoke
behaviours on SapiResource to use Ruby-conventional snake\_case
to access camelCase property names.

- Tweak gitignore
- Allow snake\_case method names for properties
- Remove redundant Rubocop warning
