### PR TITLE
Don't log API calls by default in Rails production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes will be documented in this file.
 
+## 0.8.0 - 2021-02-25
+
+- Turn off logging of calls to remote API when running in
+  production mode (if in Rails) - GH-26
+
 ## 0.7.0 - 2021-02-08
 
 - (Ian) Pass the `X-Request-ID` header to outbound calls if the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sapi-client (0.6.1)
+    sapi-client (0.7.0)
       faraday_middleware (~> 1.0.0)
       i18n (~> 1.5)
 
@@ -21,7 +21,7 @@ GEM
     faraday-net_http (1.0.1)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    i18n (1.8.8)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     minitest (5.14.3)
     minitest-reporters (1.4.3)

--- a/lib/sapi_client/version.rb
+++ b/lib/sapi_client/version.rb
@@ -2,7 +2,7 @@
 
 module SapiClient
   MAJOR = 0
-  MINOR = 7
+  MINOR = 8
   FIX = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end


### PR DESCRIPTION
Ticket #26

If we are using Sapi-client in the context of a Rails application, we
can make an assumption that our current logging practices are sufficient
and therefore we don't need to log the interaction with the API. Since
this sometimes may not be true, it can be overridden by setting the
`Rails.application.config.sapi_client_log_api_calls` config variable to
`true`.

Most of the code in this PR is in the tests, as we need to set up a
global `Rails` instance that the logger can interrogate, but ensure that
global state is cleaned up at the end of the test.

I also took the decision to perform the test by inspecting the return
result from the private method `rails_logging?`. Although we don't
normally test private methods, in this case it made for a more compact
(!) and more meaningful test, rather than attempting to actually perform
an API call and inspecting the log output. This feels more like testing
Faraday than this library.

A possible refactoring cleanup in future is to extract the
`rails_logging?` logic into a class with a public API, and then have a
private instance of that class within the `Instance` object.
