### PR TITLE
Guard against missing methods in logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes will be documented in this file.
 
+## 0.8.1 - 2021-06-18
+
+- (Ian) Guard against calling log methods when handed instance of
+  loggers that may not contain those methods
+
 ## 0.8.0 - 2021-02-25
 
 - Turn off logging of calls to remote API when running in

--- a/lib/sapi_client/instance.rb
+++ b/lib/sapi_client/instance.rb
@@ -54,10 +54,10 @@ module SapiClient
         req.headers['X-Request-ID'] = request_id if request_id
         req.params.merge! options
 
-        request_logger&.log_request(req)
+        request_logger.log_request(req) if request_logger.respond_to?(:log_request)
       end
 
-      request_logger&.log_response(r)
+      request_logger.log_response(r) if request_logger.respond_to?(:log_response)
       raise "Failed to read from #{url}: #{r.status.inspect}" unless permissible_response_code?(r)
 
       r.body

--- a/lib/sapi_client/version.rb
+++ b/lib/sapi_client/version.rb
@@ -3,6 +3,6 @@
 module SapiClient
   MAJOR = 0
   MINOR = 8
-  FIX = 0
+  FIX = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end


### PR DESCRIPTION
Per issue #28, this change hardens against calls to the given logger
instance that may not have the expected methods.
