### PR TITLE
Raise custom exceptions where there are API exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes will be documented in this file.
 
+## 0.9.0 - 2021-06-24
+
+- (Joseph) Creates a custom exception class (SapiError) specifically
+  allowing for better surfacing of http response status codes.
+
 ## 0.8.1 - 2021-06-18
 
 - (Ian) Guard against calling log methods when handed instance of

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sapi-client (0.8.0)
+    sapi-client (0.8.1)
       faraday_middleware (~> 1.0.0)
       i18n (~> 1.5)
 
@@ -12,16 +12,24 @@ GEM
     ast (2.4.2)
     builder (3.2.4)
     byebug (11.1.3)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     docile (1.3.5)
-    faraday (1.3.0)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
       faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
       multipart-post (>= 1.2, < 3)
-      ruby2_keywords
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
     faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
-    i18n (1.8.9)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     minitest (5.14.4)
     minitest-reporters (1.4.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    sapi-client (0.8.1)
+    sapi-client (0.9.0)
       faraday_middleware (~> 1.0.0)
       i18n (~> 1.5)
 

--- a/lib/sapi_client.rb
+++ b/lib/sapi_client.rb
@@ -17,17 +17,4 @@ require 'sapi_client/endpoint_values'
 require 'sapi_client/resource_wrapper'
 require 'sapi_client/hierarchy_resource'
 require 'sapi_client/hierarchy'
-
-module SapiClient
-  # Custom exception for wrapping API errors
-  class Error < StandardError
-    def initialize(message = 'Yo yo yo')
-      super
-    end
-
-    def status
-      msg = JSON.parse(message)
-      msg['status']
-    end
-  end
-end
+require 'sapi_client/sapi_error'

--- a/lib/sapi_client.rb
+++ b/lib/sapi_client.rb
@@ -19,5 +19,15 @@ require 'sapi_client/hierarchy_resource'
 require 'sapi_client/hierarchy'
 
 module SapiClient
-  class Error < StandardError; end
+  # Custom exception for wrapping API errors
+  class Error < StandardError
+    def initialize(message = 'Yo yo yo')
+      super
+    end
+
+    def status
+      msg = JSON.parse(message)
+      msg['status']
+    end
+  end
 end

--- a/lib/sapi_client/application.rb
+++ b/lib/sapi_client/application.rb
@@ -7,7 +7,7 @@ module SapiClient
   class Application
     def initialize(base_url, application_spec)
       unless File.exist?(application_spec)
-        raise(SapiClient::Error, "Could not find application spec #{application_spec}")
+        raise(SapiError, "Could not find application spec #{application_spec}")
       end
 
       @base_url = base_url

--- a/lib/sapi_client/endpoint_group.rb
+++ b/lib/sapi_client/endpoint_group.rb
@@ -6,7 +6,7 @@ module SapiClient
   class EndpointGroup
     def initialize(base_url, spec_file_name)
       unless File.exist?(spec_file_name)
-        raise(SapiClient::Error, "No such specification file: #{spec_file_name}")
+        raise(SapiError, "No such specification file: #{spec_file_name}")
       end
 
       @specification = YAML.load_stream(File.read(spec_file_name))

--- a/lib/sapi_client/instance.rb
+++ b/lib/sapi_client/instance.rb
@@ -60,6 +60,8 @@ module SapiClient
       request_logger.log_response(r) if request_logger.respond_to?(:log_response)
       raise "Failed to read from #{url}: #{r.status.inspect}" unless permissible_response_code?(r)
 
+      raise StandardError, r.body if r.status >= 400
+
       r.body
     end
 

--- a/lib/sapi_client/instance.rb
+++ b/lib/sapi_client/instance.rb
@@ -27,7 +27,7 @@ module SapiClient
 
     def get_items(url, options = {})
       wrapper = options.delete(:wrapper)
-      raise(SapiClient::Error, "Unexpected relative URL #{url}") unless absolute_url?(url)
+      raise(SapiError, "Unexpected relative URL #{url}") unless absolute_url?(url)
 
       json = get_json(url, options)
       items = json['error'] ? [json] : json['items'] || []
@@ -58,9 +58,7 @@ module SapiClient
       end
 
       request_logger.log_response(r) if request_logger.respond_to?(:log_response)
-      raise "Failed to read from #{url}: #{r.status.inspect}" unless permissible_response_code?(r)
-
-      raise Error, r.body if r.status >= 400
+      raise SapiError.new(r.body, r.status) unless permissible_response_code?(r)
 
       r.body
     end
@@ -90,7 +88,7 @@ module SapiClient
     # Any 2xx code is permissible, but we also allow 404 on the assumption that
     # the response includes a JSON description of the error
     def permissible_response_codes
-      (200..207).to_a.push(404)
+      (200..207).to_a
     end
 
     def absolute_url?(url)

--- a/lib/sapi_client/instance.rb
+++ b/lib/sapi_client/instance.rb
@@ -60,7 +60,7 @@ module SapiClient
       request_logger.log_response(r) if request_logger.respond_to?(:log_response)
       raise "Failed to read from #{url}: #{r.status.inspect}" unless permissible_response_code?(r)
 
-      raise StandardError, r.body if r.status >= 400
+      raise Error, r.body if r.status >= 400
 
       r.body
     end

--- a/lib/sapi_client/sapi_endpoint.rb
+++ b/lib/sapi_client/sapi_endpoint.rb
@@ -18,7 +18,7 @@ module SapiClient
     ].freeze
 
     def initialize(base_url, views_register, specification)
-      raise(SapiClient::Error, 'Missing specification type') unless specification.key?('type')
+      raise(SapiError, 'Missing specification type') unless specification.key?('type')
 
       @base_url = base_url
       @views_register = views_register
@@ -26,7 +26,7 @@ module SapiClient
       @type = specification['type']
       return if ENDPOINT_TYPES.include?(@type)
 
-      raise(SapiClient::Error, "Unknown endpoint type: #{@type}")
+      raise(SapiError, "Unknown endpoint type: #{@type}")
     end
 
     attr_reader :base_url, :specification, :views_register
@@ -79,7 +79,7 @@ module SapiClient
           var_name = var_name.to_sym if !options[var_name] && options[var_name.to_sym]
 
           unless options[var_name]
-            raise(SapiClient::Error, "Missing #{var_name} for endpoint path: #{raw_path}}")
+            raise(SapiError, "Missing #{var_name} for endpoint path: #{raw_path}}")
           end
 
           pth.sub(path_var[:substitution], options.delete(var_name).to_s)
@@ -133,7 +133,7 @@ module SapiClient
     def bind(options, arg_values)
       vars = path_variables(raw_path)
       if vars.length != arg_values.length
-        raise(SapiClient::Error, "Mismatched args to bind: #{vars.inspect} / #{arg_values.inspect}")
+        raise(SapiError, "Mismatched args to bind: #{vars.inspect} / #{arg_values.inspect}")
       end
 
       vars.zip(arg_values).each do |var_name, value|

--- a/lib/sapi_client/sapi_error.rb
+++ b/lib/sapi_client/sapi_error.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SapiClient
+  # Custom exception class for Sapi errors
+  class SapiError < RuntimeError
+    def initialize(message = 'There was a problem', status = nil)
+      super(message)
+      @status = status
+    end
+
+    def status
+      @status&.to_i
+    end
+  end
+end

--- a/lib/sapi_client/version.rb
+++ b/lib/sapi_client/version.rb
@@ -2,7 +2,7 @@
 
 module SapiClient
   MAJOR = 0
-  MINOR = 8
-  FIX = 1
+  MINOR = 9
+  FIX = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end

--- a/test/sapi_client/application_test.rb
+++ b/test/sapi_client/application_test.rb
@@ -18,7 +18,7 @@ module SapiClient
         it 'should raise an error if the spec file does not exist' do
           _(
             -> { SapiClient::Application.new(base_url, 'wimbledon/wombles.yaml') }
-          ).must_raise(SapiClient::Error)
+          ).must_raise(SapiError)
         end
 
         it 'should store the base URL' do

--- a/test/sapi_client/endpoint_group_test.rb
+++ b/test/sapi_client/endpoint_group_test.rb
@@ -20,7 +20,7 @@ module SapiClient
             lambda {
               SapiClient::EndpointGroup.new(base_url, 'test/fixtures/unified-view/endpointSpecs/womble.yaml')
             }
-          ).must_raise(SapiClient::Error)
+          ).must_raise(SapiError)
         end
       end
 

--- a/test/sapi_client/instance_test.rb
+++ b/test/sapi_client/instance_test.rb
@@ -99,7 +99,7 @@ module SapiClient
       describe '#get_missing_item' do
         it 'should raise an error when fetching from a URL that returns 404' do
           VCR.use_cassette('sapi_instance.get_missing_item') do
-            assert_raises(StandardError) do
+            assert_raises(RuntimeError) do
               instance = SapiClient::Instance.new(base_url)
               instance.get_items("#{base_url}/business/id/establishment/womble", _limit: 1)
             end
@@ -110,8 +110,8 @@ module SapiClient
           VCR.use_cassette('sapi_instance.get_missing_item') do
             instance = SapiClient::Instance.new(base_url)
             instance.get_items("#{base_url}/business/id/establishment/womble", _limit: 1)
-          rescue StandardError => e
-            _(e.status).must_equal '404'
+          rescue RuntimeError => e
+            _(e.status).must_equal 404
           end
         end
       end

--- a/test/sapi_client/instance_test.rb
+++ b/test/sapi_client/instance_test.rb
@@ -99,11 +99,10 @@ module SapiClient
       describe '#get_missing_item' do
         it 'should return a wrapped-JSON value when fetching from a URL that returns 404' do
           VCR.use_cassette('sapi_instance.get_missing_item') do
-            instance = SapiClient::Instance.new(base_url)
-            items = instance.get_items("#{base_url}/business/id/establishment/womble", _limit: 1)
-            _(items).must_be_kind_of Array
-            _(items.length).must_equal 1
-            _(items.first['status']).must_equal '404'
+            assert_raises(StandardError) do
+              instance = SapiClient::Instance.new(base_url)
+              instance.get_items("#{base_url}/business/id/establishment/womble", _limit: 1)
+            end
           end
         end
       end

--- a/test/sapi_client/instance_test.rb
+++ b/test/sapi_client/instance_test.rb
@@ -97,12 +97,21 @@ module SapiClient
       end
 
       describe '#get_missing_item' do
-        it 'should return a wrapped-JSON value when fetching from a URL that returns 404' do
+        it 'should raise an error when fetching from a URL that returns 404' do
           VCR.use_cassette('sapi_instance.get_missing_item') do
             assert_raises(StandardError) do
               instance = SapiClient::Instance.new(base_url)
               instance.get_items("#{base_url}/business/id/establishment/womble", _limit: 1)
             end
+          end
+        end
+
+        it 'should return an error-wrapped-JSON value when fetching from a URL that returns 404' do
+          VCR.use_cassette('sapi_instance.get_missing_item') do
+            instance = SapiClient::Instance.new(base_url)
+            instance.get_items("#{base_url}/business/id/establishment/womble", _limit: 1)
+          rescue StandardError => e
+            _(e.status).must_equal '404'
           end
         end
       end

--- a/test/sapi_client/sapi_endpoint_test.rb
+++ b/test/sapi_client/sapi_endpoint_test.rb
@@ -10,11 +10,11 @@ module SapiClient
     describe 'SapiEndpoint' do
       describe '#initialize' do
         it 'should reject a specification with no type' do
-          _(-> { SapiClient::SapiEndpoint.new('', {}, {}) }).must_raise SapiClient::Error
+          _(-> { SapiClient::SapiEndpoint.new('', {}, {}) }).must_raise SapiError
         end
 
         it 'should reject a specification with a non-permitted type' do
-          _(-> { SapiClient::SapiEndpoint.new('', {}, 'type' => 'womble') }).must_raise SapiClient::Error
+          _(-> { SapiClient::SapiEndpoint.new('', {}, 'type' => 'womble') }).must_raise SapiError
         end
 
         it 'should accept a well-formed specification without raising' do
@@ -74,7 +74,7 @@ module SapiClient
 
         it 'should raise an error if a path variable substitution is missing' do
           ep = SapiClient::SapiEndpoint.new('http://foo.bar', {}, 'type' => 'item', 'url' => '/womble/{__id}')
-          _(-> { ep.path(ID: 42) }).must_raise(SapiClient::Error)
+          _(-> { ep.path(ID: 42) }).must_raise(SapiError)
         end
 
         it 'should allow path params to be either symbols or strings' do
@@ -187,7 +187,7 @@ module SapiClient
           ep = SapiClient::SapiEndpoint.new('http://foo.bar', {}, 'type' => 'item', 'url' => '/womble/{__id}/clan/{clan}')
 
           options = {}
-          _(-> { ep.bind(options, [42]) }).must_raise(SapiClient::Error)
+          _(-> { ep.bind(options, [42]) }).must_raise(SapiError)
         end
       end
     end


### PR DESCRIPTION
Creates a custom exception class specifically to return HTTP response codes from the API where there are exceptions.
This allows us to respond appropriately in e.g. a Rails application, dependent on the API for fetching data, where no data is found/returned.