### PR TITLE
Remove errant call to require byebug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes will be documented in this file.
 
+## 0.9.1 - 2022-03-07
+
+- (Ian) Remove errant require of `byebug`
+
 ## 0.9.0 - 2021-06-24
 
 - (Joseph) Creates a custom exception class (SapiError) specifically

--- a/lib/sapi_client/instance.rb
+++ b/lib/sapi_client/instance.rb
@@ -1,8 +1,5 @@
 # frozen-string-literal: true
 
-require 'logger'
-require 'byebug'
-
 module SapiClient
   # Denotes a particular instance of a Sapi-NT API. The instance has the basic
   # capability of invoking a generic endpoint by URL, and we the augment this

--- a/lib/sapi_client/version.rb
+++ b/lib/sapi_client/version.rb
@@ -3,6 +3,6 @@
 module SapiClient
   MAJOR = 0
   MINOR = 9
-  FIX = 0
+  FIX = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end


### PR DESCRIPTION
Resolves #39 by removing a call to `require byebug` that was an
accidental by-product of an earlier bug investigation.
