### PR TITLE
Instrument API call duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes will be documented in this file.
 
+## 1.1.2 - 2022-27-03
+
+- (Ian) Record the duration of the API call and add to instrumentation
+- (Ian) Change instrumentation namespace to generic `api`, rather than `sapi_nt`
+
 ## 1.1.1 - 2022-03-18
 
 - (Ian) Fix reported issue in which view name was not recognised when it was

--- a/lib/sapi_client/version.rb
+++ b/lib/sapi_client/version.rb
@@ -3,6 +3,6 @@
 module SapiClient
   MAJOR = 1
   MINOR = 1
-  FIX = 1
+  FIX = 2
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end

--- a/test/sapi_client/instance_test.rb
+++ b/test/sapi_client/instance_test.rb
@@ -270,7 +270,7 @@ module SapiClient
             Object.const_set('Rails', mock_rails)
 
             mock_notifications = mock('Notifications')
-            mock_notifications.expects(:instrument).with { |event, _payload| event == 'response.sapi_nt' }
+            mock_notifications.expects(:instrument).with { |event, _payload| event == 'response.api' }
 
             mock_active_support = Module.new
             mock_active_support.const_set('Notifications', mock_notifications)
@@ -302,7 +302,7 @@ module SapiClient
 
             mock_notifications = mock('Notifications')
             mock_notifications.expects(:instrument).with do |event, _payload|
-              event == 'connection_failure.sapi_nt'
+              event == 'connection_failure.api'
             end
 
             mock_active_support = Module.new


### PR DESCRIPTION
To address #46, this commit measures the duration of a successful API
call, and reports this as part of the ActiveSupport notification
instrumentation.

This commit also changes the instrumentation namespace from `sapi_nt` to
`api`, per team discussion.
